### PR TITLE
Add `LoopDataManager`-level testing for auto bolus clamping

### DIFF
--- a/Loop/Managers/DoseMath.swift
+++ b/Loop/Managers/DoseMath.swift
@@ -329,19 +329,17 @@ extension Collection where Element: GlucoseValue {
                 minTarget: minGlucoseTargets.lowerBound,
                 units: units
             )
-        } else if eventual.quantity > eventualGlucoseTargets.upperBound,
-            var minCorrectionUnits = minCorrectionUnits, let correctingGlucose = correctingGlucose
-        {
-            // Limit automatic dosing to prevent insulinOnBoard > automaticDosingIOBLimit
-            if let automaticDosingIOBLimit = automaticDosingIOBLimit,
-               let insulinOnBoard = insulinOnBoard,
-               minCorrectionUnits > 0
+        } else if eventual.quantity > eventualGlucoseTargets.upperBound, var minCorrectionUnits = minCorrectionUnits, let correctingGlucose = correctingGlucose {
+            /// Don't allow the correction units + current `insulinOnBoard` to go over `automaticDosingIOBLimit`
+            if
+                let automaticDosingIOBLimit,
+                let insulinOnBoard,
+                minCorrectionUnits > 0,
+                insulinOnBoard + minCorrectionUnits > automaticDosingIOBLimit
             {
-                let checkAutomaticDosing = automaticDosingIOBLimit - (insulinOnBoard + minCorrectionUnits)
-                if checkAutomaticDosing < 0 {
-                    // TO DO - nice to have logging but not required
-                    minCorrectionUnits = Swift.max(minCorrectionUnits+checkAutomaticDosing, 0)
-                }
+                let unitsOverAutomaticDosingLimit = (insulinOnBoard + minCorrectionUnits) - automaticDosingIOBLimit
+                // TO DO - nice to have logging but not required
+                minCorrectionUnits = Swift.max(minCorrectionUnits - unitsOverAutomaticDosingLimit, 0)
             }
 
             return .aboveRange(

--- a/LoopTests/Mock Stores/MockCarbStore.swift
+++ b/LoopTests/Mock Stores/MockCarbStore.swift
@@ -124,7 +124,7 @@ extension MockCarbStore {
             return "flat_and_stable_carb_effect"
         case .highAndStable:
             return "high_and_stable_carb_effect"
-        case .highAndRisingWithCOB:
+        case .highAndRisingWithCOB, .autoBolusIOBClamping:
             return "high_and_rising_with_cob_carb_effect"
         case .lowAndFallingWithCOB:
             return "low_and_falling_carb_effect"

--- a/LoopTests/Mock Stores/MockDoseStore.swift
+++ b/LoopTests/Mock Stores/MockDoseStore.swift
@@ -60,7 +60,12 @@ class MockDoseStore: DoseStoreProtocol {
     }
     
     func insulinOnBoard(at date: Date, completion: @escaping (DoseStoreResult<InsulinValue>) -> Void) {
-        completion(.failure(.configurationError))
+        switch testType {
+        case .highAndRisingWithCOB, .autoBolusIOBClamping:
+            completion(.success(.init(startDate: MockDoseStore.currentDate(for: testType), value: 9.5)))
+        default:
+            completion(.failure(.configurationError))
+        }
     }
     
     func generateDiagnosticReport(_ completion: @escaping (String) -> Void) {
@@ -112,7 +117,7 @@ class MockDoseStore: DoseStoreProtocol {
             return dateFormatter.date(from: "2020-08-11T20:45:02")!
         case .highAndStable:
             return dateFormatter.date(from: "2020-08-12T12:39:22")!
-        case .highAndRisingWithCOB:
+        case .highAndRisingWithCOB, .autoBolusIOBClamping:
             return dateFormatter.date(from: "2020-08-11T21:48:17")!
         case .lowAndFallingWithCOB:
             return dateFormatter.date(from: "2020-08-11T22:06:06")!
@@ -140,7 +145,7 @@ extension MockDoseStore {
             return "flat_and_stable_insulin_effect"
         case .highAndStable:
             return "high_and_stable_insulin_effect"
-        case .highAndRisingWithCOB:
+        case .highAndRisingWithCOB, .autoBolusIOBClamping:
             return "high_and_rising_with_cob_insulin_effect"
         case .lowAndFallingWithCOB:
             return "low_and_falling_insulin_effect"

--- a/LoopTests/Mock Stores/MockGlucoseStore.swift
+++ b/LoopTests/Mock Stores/MockGlucoseStore.swift
@@ -112,7 +112,7 @@ extension MockGlucoseStore {
             return "flat_and_stable_counteraction_effect"
         case .highAndStable:
             return "high_and_stable_counteraction_effect"
-        case .highAndRisingWithCOB:
+        case .highAndRisingWithCOB, .autoBolusIOBClamping:
             return "high_and_rising_with_cob_counteraction_effect"
         case .lowAndFallingWithCOB:
             return "low_and_falling_counteraction_effect"
@@ -129,7 +129,7 @@ extension MockGlucoseStore {
             return "flat_and_stable_momentum_effect"
         case .highAndStable:
             return "high_and_stable_momentum_effect"
-        case .highAndRisingWithCOB:
+        case .highAndRisingWithCOB, .autoBolusIOBClamping:
             return "high_and_rising_with_cob_momentum_effect"
         case .lowAndFallingWithCOB:
             return "low_and_falling_momentum_effect"
@@ -146,7 +146,7 @@ extension MockGlucoseStore {
             return dateFormatter.date(from: "2020-08-11T20:45:02")!
         case .highAndStable:
             return dateFormatter.date(from: "2020-08-12T12:39:22")!
-        case .highAndRisingWithCOB:
+        case .highAndRisingWithCOB, .autoBolusIOBClamping:
             return dateFormatter.date(from: "2020-08-11T21:48:17")!
         case .lowAndFallingWithCOB:
             return dateFormatter.date(from: "2020-08-11T22:06:06")!
@@ -163,7 +163,7 @@ extension MockGlucoseStore {
             return 123.42849966275706
         case .highAndStable:
             return 200.0
-        case .highAndRisingWithCOB:
+        case .highAndRisingWithCOB, .autoBolusIOBClamping:
             return 129.93174411197853
         case .lowAndFallingWithCOB:
             return 75.10768374646841

--- a/LoopTests/ViewModels/BolusEntryViewModelTests.swift
+++ b/LoopTests/ViewModels/BolusEntryViewModelTests.swift
@@ -764,6 +764,8 @@ fileprivate class MockLoopState: LoopState {
     
     var carbsOnBoard: CarbValue?
     
+    var insulinOnBoard: InsulinValue?
+    
     var error: LoopError?
     
     var insulinCounteractionEffects: [GlucoseEffectVelocity] = []


### PR DESCRIPTION
As discussed on Zulip, I've added a `LoopDataManager` unit test to test the `maxBolus`-based clamping of automatic doses. I also changed the type of insulinOnBoard that LoopDataManager stores to be an `InsulinValue` (for more log/debug data) and simplified some of the dose clamping logic so it's easier to read. 

Feel free to not take the dose clamping logic changes, Marion, if you prefer what you currently have (it's in a separate commit to make doing so easier).